### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: adopt
+          distribution: 'temurin'
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,12 @@
 name: Java CI
-
-on: [push, pull_request_target]
-
+on:
+  - push
+  - pull_request_target
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
@@ -15,7 +14,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '17'
-          distribution: 'adopt'
+          distribution: adopt
           cache: maven
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots verify


### PR DESCRIPTION
This PR updates GitHub Actions versions:
- actions/checkout from v2 to v4
- actions/setup-java from v2 to v4